### PR TITLE
Better magento detection

### DIFF
--- a/systems/Magento.php
+++ b/systems/Magento.php
@@ -21,8 +21,16 @@ class Magento
      */
     public function mage_cookies_path()
     {
-        if(strstr($this->home_html, 'Mage.Cookies.path')) {
-            return true;
+        libxml_use_internal_errors(true); // stop html5 tags causing errors
+
+        $dom = new DOMDocument();
+        $dom->loadHTML($this->home_html);
+        $scripts = $dom->getElementsByTagName('script');
+        foreach($scripts as $script) {
+            $value = $script->nodeValue;
+            if(strstr($value, 'Mage.Cookies.path')) {
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
The old code would detect Magento as the CMS if the Mage.Cookies.path was in the body, e.g. in a tutorial or documentation
