### PR TITLE
Update Concrete5.php

### DIFF
--- a/src/DetectCMS/Systems/Concrete5.php
+++ b/src/DetectCMS/Systems/Concrete5.php
@@ -27,9 +27,11 @@ class Concrete5 extends \DetectCMS\DetectCMS
             require_once __DIR__ . '/../Thirdparty/simple_html_dom.php';
 
             $html = str_get_html($this->home_html);
-
-            if ($generator = $html->find("meta[name='generator']", false)) {
-                return stripos($generator->content, 'concrete5') !== false;
+            
+            if(!empty($html)) {
+                if ($generator = $html->find("meta[name='generator']", false)) {
+                    return stripos($generator->content, 'concrete5') !== false;
+                }
             }
         }
 


### PR DESCRIPTION
some time $html is empty and therefor are giving a error msg. Needs to check that it is not empty before using find()